### PR TITLE
chore: fontの分割ファイルを言語集計から除外

### DIFF
--- a/assets/.gitattributes
+++ b/assets/.gitattributes
@@ -1,0 +1,1 @@
+css/fonts.css linguist-generated


### PR DESCRIPTION
割とクソどうでもいいけどたしかにこのプロジェクトはCSSではないので